### PR TITLE
handle error state handy

### DIFF
--- a/app/src/main/java/es/ffgiraldez/comicsearch/comics/data/ComicRepository.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/comics/data/ComicRepository.kt
@@ -2,10 +2,12 @@ package es.ffgiraldez.comicsearch.comics.data
 
 import arrow.core.Either
 import arrow.core.None
+import arrow.core.Option
 import arrow.core.Some
 import es.ffgiraldez.comicsearch.comics.domain.ComicError
 import es.ffgiraldez.comicsearch.comics.domain.ComicError.EmptyResultsError
 import es.ffgiraldez.comicsearch.comics.domain.ComicError.NetworkError
+import es.ffgiraldez.comicsearch.comics.domain.Query
 import es.ffgiraldez.comicsearch.platform.left
 import es.ffgiraldez.comicsearch.platform.right
 import io.reactivex.Flowable
@@ -16,19 +18,38 @@ abstract class ComicRepository<T>(
 ) {
     fun findByTerm(term: String): Flowable<Either<ComicError, List<T>>> =
             local.findQueryByTerm(term)
-                    .flatMap {
-                        when (it) {
-                            is None -> remote.findByTerm(term)
-                                    .map { right<ComicError, List<T>>(it) }
-                                    .onErrorReturn { left<ComicError, List<T>>(NetworkError) }
-                                    .toFlowable()
-                            is Some -> local.findByQuery(it.t)
-                                    .map {
-                                        when (it.isEmpty()) {
-                                            true -> Either.left(EmptyResultsError)
-                                            false -> Either.right(it)
-                                        }
-                                    }
+                    .flatMap { findSuggestions(it, term) }
+
+    private fun findSuggestions(
+            query: Option<Query>,
+            term: String
+    ): Flowable<out Either<ComicError, List<T>>> = when (query) {
+        is None -> searchSuggestions(term)
+        is Some -> fetchSuggestions(query)
+    }
+
+    private fun searchSuggestions(term: String): Flowable<Either<ComicError, List<T>>> =
+            remote.findByTerm(term)
+                    .map { right<ComicError, List<T>>(it) }
+                    .onErrorReturn { left<ComicError, List<T>>(NetworkError) }
+                    .flatMapPublisher { saveSuggestions(it, term) }
+
+    private fun saveSuggestions(
+            results: Either<ComicError, List<T>>,
+            term: String
+    ): Flowable<Either<ComicError, List<T>>> =
+            results.fold({ _ ->
+                Flowable.just(results)
+            }, {
+                local.insert(term, it).toFlowable<Either<ComicError, List<T>>>()
+            })
+
+    private fun fetchSuggestions(it: Some<Query>): Flowable<Either<EmptyResultsError, List<T>>> =
+            local.findByQuery(it.t)
+                    .map {
+                        when (it.isEmpty()) {
+                            true -> Either.left(EmptyResultsError)
+                            false -> Either.right(it)
                         }
                     }
 }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/comics/data/ComicRepository.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/comics/data/ComicRepository.kt
@@ -1,7 +1,13 @@
 package es.ffgiraldez.comicsearch.comics.data
 
+import arrow.core.Either
 import arrow.core.None
 import arrow.core.Some
+import es.ffgiraldez.comicsearch.comics.domain.ComicError
+import es.ffgiraldez.comicsearch.comics.domain.ComicError.EmptyResultsError
+import es.ffgiraldez.comicsearch.comics.domain.ComicError.NetworkError
+import es.ffgiraldez.comicsearch.platform.left
+import es.ffgiraldez.comicsearch.platform.right
 import io.reactivex.Flowable
 
 abstract class ComicRepository<T>(
@@ -15,6 +21,29 @@ abstract class ComicRepository<T>(
                             is None -> remote.findByTerm(term)
                                     .flatMapPublisher { local.insert(term, it).toFlowable<List<T>>() }
                             is Some -> local.findByQuery(it.t)
+                        }
+                    }
+}
+
+abstract class ComicRepositoryEither<T>(
+        private val local: ComicLocalDataSource<T>,
+        private val remote: ComicRemoteDataSource<T>
+) {
+    fun findByTerm(term: String): Flowable<Either<ComicError, List<T>>> =
+            local.findQueryByTerm(term)
+                    .flatMap {
+                        when (it) {
+                            is None -> remote.findByTerm(term)
+                                    .map { right<ComicError, List<T>>(it) }
+                                    .onErrorReturn { left<ComicError, List<T>>(NetworkError) }
+                                    .toFlowable()
+                            is Some -> local.findByQuery(it.t)
+                                    .map {
+                                        when (it.isEmpty()) {
+                                            true -> Either.left(EmptyResultsError)
+                                            false -> Either.right(it)
+                                        }
+                                    }
                         }
                     }
 }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/comics/data/ComicRepository.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/comics/data/ComicRepository.kt
@@ -14,21 +14,6 @@ abstract class ComicRepository<T>(
         private val local: ComicLocalDataSource<T>,
         private val remote: ComicRemoteDataSource<T>
 ) {
-    fun findByTerm(term: String): Flowable<List<T>> =
-            local.findQueryByTerm(term)
-                    .flatMap {
-                        when (it) {
-                            is None -> remote.findByTerm(term)
-                                    .flatMapPublisher { local.insert(term, it).toFlowable<List<T>>() }
-                            is Some -> local.findByQuery(it.t)
-                        }
-                    }
-}
-
-abstract class ComicRepositoryEither<T>(
-        private val local: ComicLocalDataSource<T>,
-        private val remote: ComicRemoteDataSource<T>
-) {
     fun findByTerm(term: String): Flowable<Either<ComicError, List<T>>> =
             local.findQueryByTerm(term)
                     .flatMap {

--- a/app/src/main/java/es/ffgiraldez/comicsearch/comics/di/comicModule.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/comics/di/comicModule.kt
@@ -11,7 +11,6 @@ import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 
-const val ACTIVITY_PARAM: String = "activity"
 const val CONTEXT_PARAM: String = "context"
 
 val comicModule = applicationContext {

--- a/app/src/main/java/es/ffgiraldez/comicsearch/comics/domain/Entities.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/comics/domain/Entities.kt
@@ -10,3 +10,8 @@ data class Query(
         val identifier: Long,
         val searchTerm: String
 )
+
+sealed class ComicError {
+    object NetworkError : ComicError()
+    object EmptyResultsError : ComicError()
+}

--- a/app/src/main/java/es/ffgiraldez/comicsearch/navigation/di/androidModule.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/navigation/di/androidModule.kt
@@ -4,7 +4,6 @@ import es.ffgiraldez.comicsearch.navigation.Navigator
 import org.koin.dsl.module.applicationContext
 
 const val ACTIVITY_PARAM: String = "activity"
-const val CONTEXT_PARAM: String = "context"
 
 val navigationModule = applicationContext {
     factory { params -> Navigator(params[ACTIVITY_PARAM]) }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/platform/Utilities.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/platform/Utilities.kt
@@ -1,0 +1,16 @@
+package es.ffgiraldez.comicsearch.platform
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+
+fun <A, B, C> safe(first: A?, second: B?, block: (A, B) -> C): C? {
+    return if (first != null && second != null) {
+        block(first, second)
+    } else {
+        null
+    }
+}
+
+fun <A, B> left(a: A): Either<A, B> = a.left()
+fun <A, B> right(b: B): Either<A, B> = b.right()

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/base/presentation/QueryViewModel.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/base/presentation/QueryViewModel.kt
@@ -2,6 +2,10 @@ package es.ffgiraldez.comicsearch.query.base.presentation
 
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
+import arrow.core.Option
+import arrow.core.none
+import arrow.core.some
+import es.ffgiraldez.comicsearch.comics.domain.ComicError
 import es.ffgiraldez.comicsearch.platform.toFlowable
 import io.reactivex.Flowable
 import org.reactivestreams.Publisher
@@ -11,6 +15,7 @@ open class QueryViewModel<T>(
 ) : ViewModel() {
 
     val query: MutableLiveData<String> = MutableLiveData()
+    val error: MutableLiveData<Option<ComicError>> = MutableLiveData()
     val loading: MutableLiveData<Boolean> = MutableLiveData()
     val results: MutableLiveData<List<T>> = MutableLiveData()
 
@@ -19,17 +24,17 @@ open class QueryViewModel<T>(
                 .compose { transformer(it) }
                 .subscribe {
                     when (it) {
-                        QueryViewState.Idle -> applyState(false, emptyList())
-                        is QueryViewState.Loading -> applyState(true, emptyList())
-                        is QueryViewState.Result -> applyState(false, it.results)
+                        is QueryViewState.Loading -> applyState(isLoading = true)
+                        is QueryViewState.Idle -> applyState(isLoading = false)
+                        is QueryViewState.Error -> applyState(isLoading = false, error = it.error.some())
+                        is QueryViewState.Result -> applyState(isLoading = false, results = it.results)
                     }
                 }
-
-
     }
 
-    private fun applyState(isLoading: Boolean, results: List<T>) {
+    private fun applyState(isLoading: Boolean, results: List<T> = emptyList(), error: Option<ComicError> = none()) {
         this.loading.postValue(isLoading)
         this.results.postValue(results)
+        this.error.postValue(error)
     }
 }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/base/presentation/QueryViewState.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/base/presentation/QueryViewState.kt
@@ -1,15 +1,19 @@
 package es.ffgiraldez.comicsearch.query.base.presentation
 
+import es.ffgiraldez.comicsearch.comics.domain.ComicError
+
 sealed class QueryViewState<out T> {
 
     companion object {
         fun <T> result(volumeList: List<T>): QueryViewState<T> = Result(volumeList)
         fun <T> idle(): QueryViewState<T> = Idle
         fun <T> loading(): QueryViewState<T> = Loading
+        fun <T> error(error: ComicError): QueryViewState<T> = Error(error)
     }
 
     object Idle : QueryViewState<Nothing>()
     object Loading : QueryViewState<Nothing>()
     data class Result<out T>(val results: List<T>) : QueryViewState<T>()
+    data class Error(val error: ComicError) : QueryViewState<Nothing>()
 
 }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/ComicErrorBindingAdapter.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/ComicErrorBindingAdapter.kt
@@ -1,0 +1,8 @@
+package es.ffgiraldez.comicsearch.query.base.ui
+
+import es.ffgiraldez.comicsearch.comics.domain.ComicError
+
+fun ComicError.toHumanResponse(): String = when (this) {
+    ComicError.NetworkError -> "no internet connection"
+    ComicError.EmptyResultsError -> "search without suggestion"
+}

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/QueryActivity.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/QueryActivity.kt
@@ -4,10 +4,10 @@ import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import es.ffgiraldez.comicsearch.R
+import es.ffgiraldez.comicsearch.comics.di.CONTEXT_PARAM
 import es.ffgiraldez.comicsearch.databinding.QueryActivityBinding
-import es.ffgiraldez.comicsearch.navigation.di.ACTIVITY_PARAM
-import es.ffgiraldez.comicsearch.navigation.di.CONTEXT_PARAM
 import es.ffgiraldez.comicsearch.navigation.Navigator
+import es.ffgiraldez.comicsearch.navigation.di.ACTIVITY_PARAM
 import es.ffgiraldez.comicsearch.query.search.presentation.SearchViewModel
 import es.ffgiraldez.comicsearch.query.sugestion.presentation.SuggestionViewModel
 import org.koin.android.architecture.ext.viewModel

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/QuerySearchSuggestion.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/QuerySearchSuggestion.kt
@@ -3,9 +3,15 @@ package es.ffgiraldez.comicsearch.query.base.ui
 import com.arlib.floatingsearchview.suggestions.model.SearchSuggestion
 import kotlinx.android.parcel.Parcelize
 
-@Parcelize
-data class QuerySearchSuggestion(
-        private val volume: String
+sealed class QuerySearchSuggestion(
+        private val suggestion: String
 ) : SearchSuggestion {
-    override fun getBody(): String = volume
+    override fun getBody(): String = suggestion
+
+    @Parcelize
+    data class ResultSuggestion(val volume: String) : QuerySearchSuggestion(volume)
+
+    @Parcelize
+    data class ErrorSuggestion(val volume: String) : QuerySearchSuggestion(volume)
+
 }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/search/presentation/SearchViewModel.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/search/presentation/SearchViewModel.kt
@@ -14,7 +14,13 @@ class SearchViewModel private constructor(
         operator fun invoke(repo: SearchRepository): SearchViewModel = SearchViewModel {
             it.switchMap {
                 repo.findByTerm(it)
-                        .map { QueryViewState.result(it) }
+                        .map {
+                            it.fold({
+                                QueryViewState.error<Volume>(it)
+                            }, {
+                                QueryViewState.result(it)
+                            })
+                        }
                         .startWith(QueryViewState.loading())
             }.startWith(QueryViewState.idle())
         }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/search/presentation/SearchViewModel.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/search/presentation/SearchViewModel.kt
@@ -12,7 +12,11 @@ class SearchViewModel private constructor(
 ) : QueryViewModel<Volume>(queryToResult) {
     companion object {
         operator fun invoke(repo: SearchRepository): SearchViewModel = SearchViewModel {
-            it.switchMap {
+            it.switchMap { handleQuery(repo, it) }
+                    .startWith(QueryViewState.idle())
+        }
+
+        private fun handleQuery(repo: SearchRepository, it: String): Flowable<QueryViewState<Volume>> =
                 repo.findByTerm(it)
                         .map {
                             it.fold({
@@ -22,7 +26,5 @@ class SearchViewModel private constructor(
                             })
                         }
                         .startWith(QueryViewState.loading())
-            }.startWith(QueryViewState.idle())
-        }
     }
 }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapters.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapters.kt
@@ -11,6 +11,7 @@ import com.arlib.floatingsearchview.suggestions.model.SearchSuggestion
 import es.ffgiraldez.comicsearch.comics.domain.ComicError
 import es.ffgiraldez.comicsearch.comics.domain.Volume
 import es.ffgiraldez.comicsearch.query.base.ui.OnVolumeSelectedListener
+import es.ffgiraldez.comicsearch.query.base.ui.QuerySearchSuggestion.ResultSuggestion
 import es.ffgiraldez.comicsearch.query.base.ui.QueryVolumeAdapter
 import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
 import io.reactivex.functions.Consumer
@@ -22,10 +23,14 @@ fun bindSuggestionClick(search: FloatingSearchView, clickConsumer: ClickConsumer
             searchConsumer?.apply { searchConsumer.accept(currentQuery) }
         }
 
-        override fun onSuggestionClicked(searchSuggestion: SearchSuggestion?) {
+        override fun onSuggestionClicked(searchSuggestion: SearchSuggestion) {
             clickConsumer?.apply {
-                clickConsumer.accept(searchSuggestion)
-                search.setSearchFocused(false)
+                when (searchSuggestion) {
+                    is ResultSuggestion -> {
+                        clickConsumer.accept(searchSuggestion)
+                        search.setSearchFocused(false)
+                    }
+                }
             }
         }
     })

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapters.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapters.kt
@@ -2,11 +2,17 @@ package es.ffgiraldez.comicsearch.query.search.ui
 
 import android.databinding.BindingAdapter
 import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
+import arrow.core.Option
 import com.arlib.floatingsearchview.FloatingSearchView
 import com.arlib.floatingsearchview.suggestions.model.SearchSuggestion
+import es.ffgiraldez.comicsearch.comics.domain.ComicError
 import es.ffgiraldez.comicsearch.comics.domain.Volume
 import es.ffgiraldez.comicsearch.query.base.ui.OnVolumeSelectedListener
 import es.ffgiraldez.comicsearch.query.base.ui.QueryVolumeAdapter
+import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
 import io.reactivex.functions.Consumer
 
 @BindingAdapter("on_suggestion_click", "on_search", requireAll = false)
@@ -38,6 +44,20 @@ fun bindData(recycler: RecyclerView, queryAdapter: QueryVolumeAdapter, data: Lis
             data?.let { queryAdapter.submitList(data) }
         }
 
+@BindingAdapter("error")
+fun bindDataError(recycler: RecyclerView, errorData: Option<ComicError>?) = errorData?.let { error ->
+    error.fold({ View.VISIBLE }, { View.GONE }).let { recycler.visibility = it }
+}
+
+@BindingAdapter("error")
+fun bindErrorVisibility(errorContainer: FrameLayout, errorData: Option<ComicError>?) = errorData?.let { error ->
+    error.fold({ View.GONE }, { View.VISIBLE }).let { errorContainer.visibility = it }
+}
+
+@BindingAdapter("error")
+fun bindErrorText(errorText: TextView, errorData: Option<ComicError>?) = errorData?.let { error ->
+    error.fold({ Unit }, { errorText.text = it.toHumanResponse() })
+}
 
 interface ClickConsumer : Consumer<SearchSuggestion>
 interface SearchConsumer : Consumer<String>

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/data/SuggestionRepository.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/data/SuggestionRepository.kt
@@ -1,8 +1,8 @@
 package es.ffgiraldez.comicsearch.query.sugestion.data
 
-import es.ffgiraldez.comicsearch.comics.data.ComicRepositoryEither
+import es.ffgiraldez.comicsearch.comics.data.ComicRepository
 
 class SuggestionRepository(
         local: SuggestionLocalDataSource,
         remote: SuggestionRemoteDataSource
-) : ComicRepositoryEither<String>(local, remote)
+) : ComicRepository<String>(local, remote)

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/data/SuggestionRepository.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/data/SuggestionRepository.kt
@@ -1,8 +1,8 @@
 package es.ffgiraldez.comicsearch.query.sugestion.data
 
-import es.ffgiraldez.comicsearch.comics.data.ComicRepository
+import es.ffgiraldez.comicsearch.comics.data.ComicRepositoryEither
 
 class SuggestionRepository(
         local: SuggestionLocalDataSource,
         remote: SuggestionRemoteDataSource
-) : ComicRepository<String>(local, remote)
+) : ComicRepositoryEither<String>(local, remote)

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/presentation/SuggestionViewModel.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/presentation/SuggestionViewModel.kt
@@ -15,8 +15,13 @@ class SuggestionViewModel private constructor(
             it.debounce(400, TimeUnit.MILLISECONDS)
                     .switchMap { query ->
                         repo.findByTerm(query)
-                                .map { suggestions -> QueryViewState.result(suggestions) }
-                                .startWith(QueryViewState.loading())
+                                .map { suggestions ->
+                                    suggestions.fold({
+                                        QueryViewState.error<String>(it)
+                                    }, {
+                                        QueryViewState.result(it)
+                                    })
+                                }.startWith(QueryViewState.loading())
                     }.startWith(QueryViewState.idle())
         }
     }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapters.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapters.kt
@@ -5,7 +5,8 @@ import arrow.core.Option
 import com.arlib.floatingsearchview.FloatingSearchView
 import es.ffgiraldez.comicsearch.comics.domain.ComicError
 import es.ffgiraldez.comicsearch.platform.safe
-import es.ffgiraldez.comicsearch.query.base.ui.QuerySearchSuggestion
+import es.ffgiraldez.comicsearch.query.base.ui.QuerySearchSuggestion.ErrorSuggestion
+import es.ffgiraldez.comicsearch.query.base.ui.QuerySearchSuggestion.ResultSuggestion
 import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
 
 
@@ -14,12 +15,16 @@ fun bindQueryChangeListener(search: FloatingSearchView, listener: FloatingSearch
         search.setOnQueryChangeListener(listener)
 
 @BindingAdapter("suggestions", "error")
-fun bindSuggestions(search: FloatingSearchView, resultData: List<String>?, errorData: Option<ComicError>?) = safe(errorData, resultData) { error, results ->
+fun bindSuggestions(
+        search: FloatingSearchView,
+        resultData: List<String>?,
+        errorData: Option<ComicError>?
+) = safe(errorData, resultData) { error, results ->
     error.fold({
-        results
+        results.map { ResultSuggestion(it) }
     }, {
-        listOf(it.toHumanResponse())
-    }).map { QuerySearchSuggestion(it) }.let { search.swapSuggestions(it) }
+        listOf(ErrorSuggestion(it.toHumanResponse()))
+    }).let { search.swapSuggestions(it) }
 }
 
 @BindingAdapter("show_progress")

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapters.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapters.kt
@@ -6,6 +6,7 @@ import com.arlib.floatingsearchview.FloatingSearchView
 import es.ffgiraldez.comicsearch.comics.domain.ComicError
 import es.ffgiraldez.comicsearch.platform.safe
 import es.ffgiraldez.comicsearch.query.base.ui.QuerySearchSuggestion
+import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
 
 
 @BindingAdapter("on_change")
@@ -29,7 +30,3 @@ fun bindLoading(search: FloatingSearchView, liveData: Boolean?) = liveData?.let 
     }
 }
 
-private fun ComicError.toHumanResponse(): String = when (this) {
-    ComicError.NetworkError -> "no internet connection"
-    ComicError.EmptyResultsError -> "search without suggestion"
-}

--- a/app/src/main/res/layout/query_activity.xml
+++ b/app/src/main/res/layout/query_activity.xml
@@ -47,6 +47,7 @@
             app:on_change='@{ (old, new) -> delegate.onQueryChange(new) }'
             app:on_suggestion_click='@{ (suggestion) -> delegate.onSuggestionSelected(suggestion.body) }'
             app:show_progress='@{ delegate.suggestions.loading }'
+            app:error='@{ delegate.suggestions.error}'
             app:suggestions='@{ delegate.suggestions.results }' />
 
 

--- a/app/src/main/res/layout/query_activity.xml
+++ b/app/src/main/res/layout/query_activity.xml
@@ -15,6 +15,18 @@
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">
 
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:error='@{ delegate.suggestions.error}'>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                app:error='@{ delegate.suggestions.error}' />
+        </FrameLayout>
+
         <android.support.v7.widget.RecyclerView
             android:id="@+id/recycler"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/query_activity.xml
+++ b/app/src/main/res/layout/query_activity.xml
@@ -18,13 +18,13 @@
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:error='@{ delegate.suggestions.error}'>
+            app:error='@{ delegate.search.error}'>
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                app:error='@{ delegate.suggestions.error}' />
+                app:error='@{ delegate.search.error}' />
         </FrameLayout>
 
         <android.support.v7.widget.RecyclerView
@@ -35,6 +35,7 @@
             android:paddingTop="72dp"
             app:layoutManager="android.support.v7.widget.LinearLayoutManager"
             app:adapter="@{ delegate.adapter }"
+            app:error='@{ delegate.search.error}'
             app:on_data_change="@{ delegate.search.results }"
             app:on_selected="@{ (volume) -> delegate.onVolumeSelected(volume) }" />
 

--- a/app/src/test/java/es/ffgiraldez/comicsearch/di/TestContextResolution.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/di/TestContextResolution.kt
@@ -4,9 +4,9 @@ import android.app.Activity
 import android.arch.core.executor.testing.InstantTaskExecutorRule
 import android.content.Context
 import com.nhaarman.mockito_kotlin.mock
+import es.ffgiraldez.comicsearch.comics.di.CONTEXT_PARAM
 import es.ffgiraldez.comicsearch.comics.di.comicModule
 import es.ffgiraldez.comicsearch.navigation.di.ACTIVITY_PARAM
-import es.ffgiraldez.comicsearch.navigation.di.CONTEXT_PARAM
 import es.ffgiraldez.comicsearch.navigation.di.navigationModule
 import es.ffgiraldez.comicsearch.query.search.di.searchModule
 import es.ffgiraldez.comicsearch.query.sugestion.di.suggestionModule


### PR DESCRIPTION
### :tophat: What is the goal?
Handle error state, this sample project only have 2
* Connectivity errors
* Empty results
### :memo: How is it being implemented?
* Create a new property on `QueryViewModel` error to describe an error on UI
* Create a new `QueryViewState` error to model the state
* To not duplicate code on data sources, errors are handled on `ComicRepository`
* Model error using `Either<ComicError, List<T>>`
* Empty results on `ComicLocalDataSource` produce `EmptyResultsError`
* Any network error produce `NetworkError`
* Suggestion will display error as a single suggestion
* Search will display error as text on the screen, hiding result list
* Error suggestions does not propagate search results
