### PR TITLE
feat: :arrow_up: migrate to junit 5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'de.mannodermaus.android-junit5'
 
 android {
     compileSdkVersion compile_sdk
@@ -77,9 +78,11 @@ dependencies {
 
     testImplementation libs.arch_comp_room_test
     testImplementation libs.arch_comp_test
-    testImplementation libs.junit
+    testImplementation libs.junit_api
     testImplementation libs.koin_test
     testImplementation libs.mockito_kotlin
+
+    testRuntimeOnly libs.junit_engine
 }
 repositories {
     mavenCentral()

--- a/app/src/test/java/es/ffgiraldez/comicsearch/di/InstantTaskExtension.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/di/InstantTaskExtension.kt
@@ -1,0 +1,34 @@
+package es.ffgiraldez.comicsearch.di
+
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class InstantTaskExtension
+    : BeforeEachCallback, AfterEachCallback {
+    override fun beforeEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(object : TaskExecutor() {
+            override fun executeOnDiskIO(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun postToMainThread(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun isMainThread(): Boolean {
+                return true
+            }
+        })
+    }
+
+
+    override fun afterEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(null)
+    }
+
+}
+
+

--- a/app/src/test/java/es/ffgiraldez/comicsearch/di/TestContextResolution.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/di/TestContextResolution.kt
@@ -1,20 +1,16 @@
 package es.ffgiraldez.comicsearch.di
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import es.ffgiraldez.comicsearch.comics.di.comicModule
 import es.ffgiraldez.comicsearch.navigation.di.navigationModule
 import es.ffgiraldez.comicsearch.query.search.di.searchModule
 import es.ffgiraldez.comicsearch.query.sugestion.di.suggestionModule
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TestRule
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.koin.test.KoinTest
 import org.koin.test.checkModules
 
+@ExtendWith(InstantTaskExtension::class)
 class TestContextResolution : KoinTest {
-
-    @get:Rule
-    var rule: TestRule = InstantTaskExecutorRule()
 
     @Test
     fun `dry run`() {

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     dependencies {
         classpath build_plugins.android_gradle
         classpath build_plugins.kotlin_gradle
+        classpath build_plugins.android_junit
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,11 +14,13 @@ ext {
             okhttp                 : '3.11.0',
             retrofit               : '2.4.0',
             support                : '1.0.0',
+            junit                  : '5.3.2'
     ]
 
     build_plugins = [
             android_gradle: [group: 'com.android.tools.build', name: 'gradle', version: versions.android_plugin],
-            kotlin_gradle : [group: 'org.jetbrains.kotlin', name: 'kotlin-gradle-plugin', version: versions.kotlin]
+            kotlin_gradle : [group: 'org.jetbrains.kotlin', name: 'kotlin-gradle-plugin', version: versions.kotlin],
+            android_junit : [group: 'de.mannodermaus.gradle.plugins', name: 'android-junit5', version: '1.3.2.0']
     ]
 
     libs = [
@@ -34,7 +36,8 @@ ext {
             databinding_compiler   : [group: 'com.android.databinding', name: 'compiler', version: versions.android_plugin],
             design                 : [group: 'com.android.support', name: 'design', version: versions.support],
             floating_search        : [group: 'com.github.arimorty', name: 'floatingsearchview', version: '2.1.1'],
-            junit                  : [group: 'junit', name: 'junit', version: '4.12'],
+            junit_api              : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit],
+            junit_engine           : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit],
             okhttp                 : [group: 'com.squareup.okhttp3', name: 'okhttp', version: versions.okhttp],
             okhttp_logging         : [group: 'com.squareup.okhttp3', name: 'logging-interceptor', version: versions.okhttp],
             koin                   : [group: 'org.koin', name: 'koin-core', version: versions.koin],


### PR DESCRIPTION
### :tophat: What is the goal?

Migrate current test to JUnit 5

### :memo: How is it being implemented?

* Android does not support JUnit 5 out of the box, so the following [android-junit5](https://github.com/mannodermaus/android-junit5/) plugin is used
* Created the extension `InstantTaskExtension` in order to migrate `InstantTaskExecutorRule`

### :boom: How can it be tested?

🤖 run the tests 😃 