### PR TITLE
feat: :white_check_mark: create suggestion & search binding test suite

### DIFF
--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/QuerySearchSuggestion.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/base/ui/QuerySearchSuggestion.kt
@@ -12,6 +12,6 @@ sealed class QuerySearchSuggestion(
     data class ResultSuggestion(val volume: String) : QuerySearchSuggestion(volume)
 
     @Parcelize
-    data class ErrorSuggestion(val volume: String) : QuerySearchSuggestion(volume)
+    data class ErrorSuggestion(val error: String) : QuerySearchSuggestion(error)
 
 }

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapters.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapters.kt
@@ -26,8 +26,8 @@ interface ClickConsumer : Consumer<SearchSuggestion>
 interface SearchConsumer : Consumer<String>
 
 @BindingAdapter("on_suggestion_click", "on_search", requireAll = false)
-fun bindSuggestionClick(search: FloatingSearchView, clickConsumer: ClickConsumer?, searchConsumer: SearchConsumer?) {
-    search.setOnSearchListener(object : FloatingSearchView.OnSearchListener {
+fun FloatingSearchView.bindSuggestionClick(clickConsumer: ClickConsumer?, searchConsumer: SearchConsumer?) {
+    setOnSearchListener(object : FloatingSearchView.OnSearchListener {
         override fun onSearchAction(currentQuery: String) {
             searchConsumer?.apply { searchConsumer.accept(currentQuery) }
         }
@@ -37,7 +37,7 @@ fun bindSuggestionClick(search: FloatingSearchView, clickConsumer: ClickConsumer
                 when (searchSuggestion) {
                     is ResultSuggestion -> {
                         clickConsumer.accept(searchSuggestion)
-                        search.setSearchFocused(false)
+                        setSearchFocused(false)
                     }
                 }
             }
@@ -49,32 +49,32 @@ fun bindSuggestionClick(search: FloatingSearchView, clickConsumer: ClickConsumer
  * Limit scope to apply using RecyclerView as BindingAdapter
  */
 @BindingAdapter("adapter", "state_change", "on_selected", requireAll = false)
-fun bindStateData(recycler: RecyclerView, inputAdapter: QueryVolumeAdapter, data: QueryViewState<Volume>?, consumer: OnVolumeSelectedListener) =
-        with(recycler) {
-            if (adapter == null) {
-                inputAdapter.onVolumeSelectedListener = consumer
-                adapter = inputAdapter
-            }
+fun RecyclerView.bindStateData(inputAdapter: QueryVolumeAdapter, data: QueryViewState<Volume>?, consumer: OnVolumeSelectedListener) {
+    if (adapter == null) {
+        inputAdapter.onVolumeSelectedListener = consumer
+        adapter = inputAdapter
+    }
 
-            data?.let {
-                bindError(data.error)
-                bindResults(data.results)
-            }
-        }
+    data?.let {
+        bindError(data.error)
+        bindResults(data.results)
+    }
+}
+
 
 @BindingAdapter("state_change")
-fun bindStateVisibility(errorContainer: FrameLayout, data: QueryViewState<Volume>?) = data?.let { state ->
-    state.error.fold({ View.GONE }, { View.VISIBLE }).let { errorContainer.visibility = it }
+fun FrameLayout.bindStateVisibility(data: QueryViewState<Volume>?) = data?.let { state ->
+    state.error.fold({ View.GONE }, { View.VISIBLE }).let { visibility = it }
 }
 
 @BindingAdapter("state_change")
-fun bindErrorText(errorText: TextView, data: QueryViewState<Volume>?) = data?.let { state ->
-    state.error.fold({ Unit }, { errorText.text = it.toHumanResponse() })
+fun TextView.bindErrorText(data: QueryViewState<Volume>?) = data?.let { state ->
+    state.error.fold({ Unit }, { text = it.toHumanResponse() })
 }
 
 @BindingAdapter("state_change")
-fun bindProgress(progress: ProgressBar, data: QueryViewState<Volume>?) = data?.let { state ->
-    progress.gone(!state.loading)
+fun ProgressBar.bindProgress(data: QueryViewState<Volume>?) = data?.let { state ->
+    gone(!state.loading)
 }
 
 private fun RecyclerView.bindError(error: Option<ComicError>): Unit =

--- a/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapters.kt
+++ b/app/src/main/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapters.kt
@@ -11,19 +11,18 @@ import es.ffgiraldez.comicsearch.query.base.ui.results
 import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
 
 @BindingAdapter("on_change")
-fun bindQueryChangeListener(
-        search: FloatingSearchView,
+fun FloatingSearchView.bindQueryChangeListener(
         listener: FloatingSearchView.OnQueryChangeListener
-): Unit = search.setOnQueryChangeListener(listener)
+): Unit = setOnQueryChangeListener(listener)
 
 @BindingAdapter("state_change")
-fun bindSuggestions(search: FloatingSearchView, data: QueryViewState<String>?): Unit? = data?.run {
-    search.toggleProgress(loading)
-    error.fold({
-        results.map { ResultSuggestion(it) }
+fun FloatingSearchView.bindSuggestions(data: QueryViewState<String>?): Unit? = data?.let { state ->
+    toggleProgress(state.loading)
+    state.error.fold({
+        state.results.map { ResultSuggestion(it) }
     }, {
         listOf(ErrorSuggestion(it.toHumanResponse()))
-    }).let { search.swapSuggestions(it) }
+    }).let(::swapSuggestions)
 }
 
 private fun FloatingSearchView.toggleProgress(show: Boolean): Unit = when (show) {

--- a/app/src/test/java/es/ffgiraldez/comicsearch/comic/gen/EntitiesGen.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/comic/gen/EntitiesGen.kt
@@ -5,7 +5,9 @@ import es.ffgiraldez.comicsearch.comics.domain.ComicError
 import es.ffgiraldez.comicsearch.comics.domain.Volume
 import es.ffgiraldez.comicsearch.platform.left
 import es.ffgiraldez.comicsearch.platform.right
+import es.ffgiraldez.comicsearch.query.base.presentation.QueryViewState
 import io.kotlintest.properties.Gen
+import io.kotlintest.properties.filterIsInstance
 
 class ComicErrorGenerator : Gen<ComicError> {
     override fun constants(): Iterable<ComicError> = emptyList()
@@ -67,8 +69,18 @@ class SearchGenerator : Gen<Either<ComicError, List<Volume>>> {
     }
 }
 
-
 fun Gen.Companion.suggestions(): Gen<Either<ComicError, List<String>>> = SuggestionGenerator()
+
+fun Gen.Companion.suggestionsViewState(): Gen<QueryViewState<String>> = Gen.suggestions().map { suggestion ->
+    suggestion.fold(
+            { QueryViewState.error<String>(it) },
+            { QueryViewState.result(it) }
+    )
+}
+
+fun Gen.Companion.suggestionsErrorViewState(): Gen<QueryViewState.Error> = suggestionsViewState().filterIsInstance()
+
+fun Gen.Companion.suggestionsResultViewState(): Gen<QueryViewState.Result<String>> = suggestionsViewState().filterIsInstance()
 
 fun Gen.Companion.search(): Gen<Either<ComicError, List<Volume>>> = SearchGenerator()
 

--- a/app/src/test/java/es/ffgiraldez/comicsearch/comic/gen/EntitiesGen.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/comic/gen/EntitiesGen.kt
@@ -69,14 +69,24 @@ class SearchGenerator : Gen<Either<ComicError, List<Volume>>> {
     }
 }
 
+class SearchViewStateGenerator : Gen<QueryViewState<Volume>> {
+    override fun constants(): Iterable<QueryViewState<Volume>> = listOf(
+            QueryViewState.idle(),
+            QueryViewState.loading()
+    )
+
+    override fun random(): Sequence<QueryViewState<Volume>> = Gen.search().random().map { search ->
+        search.fold(
+                { QueryViewState.error<Volume>(it) },
+                { QueryViewState.result(it) }
+        )
+    }
+
+}
+
 fun Gen.Companion.suggestions(): Gen<Either<ComicError, List<String>>> = SuggestionGenerator()
 
-fun Gen.Companion.suggestionsViewState(): Gen<QueryViewState<String>> = Gen.suggestions().map { suggestion ->
-    suggestion.fold(
-            { QueryViewState.error<String>(it) },
-            { QueryViewState.result(it) }
-    )
-}
+fun Gen.Companion.suggestionsViewState(): Gen<QueryViewState<String>> = SuggestionViewStateGenerator()
 
 fun Gen.Companion.suggestionsErrorViewState(): Gen<QueryViewState.Error> = suggestionsViewState().filterIsInstance()
 
@@ -89,3 +99,9 @@ fun Gen.Companion.comicError(): Gen<ComicError> = ComicErrorGenerator()
 fun Gen.Companion.query(): Gen<String> = QueryGenerator()
 
 fun Gen.Companion.volume(): Gen<Volume> = VolumeGenerator()
+
+fun Gen.Companion.searchViewState(): Gen<QueryViewState<Volume>> = SearchViewStateGenerator()
+
+fun Gen.Companion.searchErrorViewState(): Gen<QueryViewState.Error> = searchViewState().filterIsInstance()
+
+fun Gen.Companion.searchResultViewState(): Gen<QueryViewState.Result<Volume>> = searchViewState().filterIsInstance()

--- a/app/src/test/java/es/ffgiraldez/comicsearch/comic/gen/EntitiesGen.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/comic/gen/EntitiesGen.kt
@@ -40,6 +40,20 @@ class SuggestionGenerator : Gen<Either<ComicError, List<String>>> {
     }
 }
 
+class SuggestionViewStateGenerator : Gen<QueryViewState<String>> {
+    override fun constants(): Iterable<QueryViewState<String>> = listOf(
+            QueryViewState.idle(),
+            QueryViewState.loading()
+    )
+
+    override fun random(): Sequence<QueryViewState<String>> = Gen.suggestions().random().map { suggestion ->
+        suggestion.fold(
+                { QueryViewState.error<String>(it) },
+                { QueryViewState.result(it) }
+        )
+    }
+}
+
 class VolumeGenerator : Gen<Volume> {
     override fun constants(): Iterable<Volume> = emptyList()
 

--- a/app/src/test/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapterSpec.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/query/search/ui/SearchBindingAdapterSpec.kt
@@ -1,0 +1,211 @@
+package es.ffgiraldez.comicsearch.query.search.ui
+
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.arlib.floatingsearchview.FloatingSearchView
+import com.arlib.floatingsearchview.FloatingSearchView.OnSearchListener
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doNothing
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import es.ffgiraldez.comicsearch.comic.gen.searchErrorViewState
+import es.ffgiraldez.comicsearch.comic.gen.searchViewState
+import es.ffgiraldez.comicsearch.query.base.presentation.QueryViewState
+import es.ffgiraldez.comicsearch.query.base.ui.OnVolumeSelectedListener
+import es.ffgiraldez.comicsearch.query.base.ui.QuerySearchSuggestion.ErrorSuggestion
+import es.ffgiraldez.comicsearch.query.base.ui.QuerySearchSuggestion.ResultSuggestion
+import es.ffgiraldez.comicsearch.query.base.ui.QueryVolumeAdapter
+import es.ffgiraldez.comicsearch.query.base.ui.results
+import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.assertAll
+import io.kotlintest.specs.WordSpec
+
+class SearchBindingAdapterSpec : WordSpec({
+    "ProgressBar" should {
+        "not have interaction on null state" {
+            val progressBar = mock<ProgressBar>()
+
+            progressBar.bindProgress(null)
+
+            verifyZeroInteractions(progressBar)
+        }
+
+        "be visible on loading state" {
+            val progressBar = mock<ProgressBar>()
+
+            progressBar.bindProgress(QueryViewState.loading())
+
+            verify(progressBar).visibility = eq(View.VISIBLE)
+        }
+
+        "be gone on non loading state" {
+            assertAll(Gen.searchViewState().filterNot { it is QueryViewState.Loading }) { state ->
+                val progressBar = mock<ProgressBar>()
+
+                progressBar.bindProgress(state)
+
+                verify(progressBar).visibility = eq(View.GONE)
+            }
+        }
+
+    }
+
+    "TextView" should {
+
+        "not have interaction on null state" {
+            val textView = mock<TextView>()
+
+            textView.bindErrorText(null)
+
+            verifyZeroInteractions(textView)
+        }
+
+        "not have interaction on non error state" {
+            assertAll(Gen.searchViewState().filterNot { it is QueryViewState.Error }) { state ->
+                val textView = mock<TextView>()
+
+                textView.bindErrorText(state)
+
+                verifyZeroInteractions(textView)
+            }
+        }
+
+        "show error human description on error state" {
+            assertAll(Gen.searchErrorViewState()) { state ->
+                val textView = mock<TextView>()
+
+                textView.bindErrorText(state)
+
+                verify(textView).text = eq(state._error.toHumanResponse())
+            }
+        }
+    }
+
+    "FrameLayout" should {
+        "not have interaction on null state" {
+            val frameLayout = mock<FrameLayout>()
+
+            frameLayout.bindStateVisibility(null)
+
+            verifyZeroInteractions(frameLayout)
+        }
+
+        "be gone on non error state" {
+            assertAll(Gen.searchViewState().filterNot { it is QueryViewState.Error }) { state ->
+                val frameLayout = mock<FrameLayout>()
+
+                frameLayout.bindStateVisibility(state)
+
+
+                verify(frameLayout).visibility = eq(View.GONE)
+            }
+        }
+
+        "be visible on error state" {
+            assertAll(Gen.searchErrorViewState()) { state ->
+                val frameLayout = mock<FrameLayout>()
+
+                frameLayout.bindStateVisibility(state)
+
+
+                verify(frameLayout).visibility = eq(View.VISIBLE)
+            }
+        }
+    }
+
+    "RecyclerView" should {
+        "configure is adapter when is not defined" {
+            val recyclerView = mock<RecyclerView>()
+            val adapter = mock<QueryVolumeAdapter>()
+            val onVolumeSelected = mock<OnVolumeSelectedListener>()
+
+            recyclerView.bindStateData(adapter, null, onVolumeSelected)
+
+            verify(recyclerView).adapter = eq(adapter)
+            verify(adapter).onVolumeSelectedListener = eq(onVolumeSelected)
+        }
+
+        "update result list on state change" {
+            assertAll(Gen.searchViewState()) { state ->
+                val adapter = mock<QueryVolumeAdapter>()
+                val recyclerView = mock<RecyclerView> {
+                    on { getAdapter() }.thenReturn(adapter)
+                }
+                val onVolumeSelected = mock<OnVolumeSelectedListener>()
+
+                recyclerView.bindStateData(adapter, state, onVolumeSelected)
+
+                verify(adapter).submitList(eq(state.results))
+            }
+        }
+
+
+        "be visible on non error state" {
+            assertAll(Gen.searchViewState().filterNot { it is QueryViewState.Error }) { state ->
+                val adapter = mock<QueryVolumeAdapter>()
+                val recyclerView = mock<RecyclerView> {
+                    on { getAdapter() }.thenReturn(adapter)
+                }
+                val onVolumeSelected = mock<OnVolumeSelectedListener>()
+
+                recyclerView.bindStateData(adapter, state, onVolumeSelected)
+
+                verify(recyclerView).visibility = eq(View.VISIBLE)
+            }
+        }
+
+        "be gone on non error state" {
+            assertAll(Gen.searchErrorViewState()) { state ->
+                val adapter = mock<QueryVolumeAdapter>()
+                val recyclerView = mock<RecyclerView> {
+                    on { getAdapter() }.thenReturn(adapter)
+                }
+                val onVolumeSelected = mock<OnVolumeSelectedListener>()
+
+                recyclerView.bindStateData(adapter, state, onVolumeSelected)
+
+                verify(recyclerView).visibility = eq(View.GONE)
+            }
+        }
+    }
+
+    "FloatingView" should {
+        "avoid search on error suggestion click" {
+            val searchListenerCaptor = argumentCaptor<OnSearchListener>()
+            val searchView = mock<FloatingSearchView> {
+                doNothing().whenever(it).setOnSearchListener(searchListenerCaptor.capture())
+            }
+            val click = mock<ClickConsumer>()
+
+
+            searchView.bindSuggestionClick(click, mock())
+
+            searchListenerCaptor.firstValue.onSuggestionClicked(ErrorSuggestion(Gen.string().random().first()))
+
+            verifyZeroInteractions(click)
+        }
+
+        "search on result suggestion click" {
+            val searchListenerCaptor = argumentCaptor<OnSearchListener>()
+            val searchView = mock<FloatingSearchView> {
+                doNothing().whenever(it).setOnSearchListener(searchListenerCaptor.capture())
+            }
+            val click = mock<ClickConsumer>()
+            val suggestion = ResultSuggestion(Gen.string().random().first())
+
+
+            searchView.bindSuggestionClick(click, mock())
+
+            searchListenerCaptor.firstValue.onSuggestionClicked(suggestion)
+
+            verify(click).accept(eq(suggestion))
+        }
+    }
+})

--- a/app/src/test/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapterSpec.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapterSpec.kt
@@ -1,0 +1,87 @@
+package es.ffgiraldez.comicsearch.query.sugestion.ui
+
+import com.arlib.floatingsearchview.FloatingSearchView
+import com.arlib.floatingsearchview.suggestions.model.SearchSuggestion
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doNothing
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import es.ffgiraldez.comicsearch.comic.gen.suggestionsErrorViewState
+import es.ffgiraldez.comicsearch.comic.gen.suggestionsResultViewState
+import es.ffgiraldez.comicsearch.query.base.presentation.QueryViewState
+import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.assertAll
+import io.kotlintest.specs.StringSpec
+import junit.framework.Assert.assertEquals
+
+
+class SuggestionBindingAdapterSpec :
+        StringSpec({
+            "FloatingSearchView should show progress on loading state" {
+                val searchView = mock<FloatingSearchView>()
+
+                searchView.bindSuggestions(QueryViewState.loading())
+
+                verify(searchView).showProgress()
+
+            }
+
+            "FloatingSearchView should hide progress on non loading state" {
+                val searchView = mock<FloatingSearchView>()
+
+                searchView.bindSuggestions(QueryViewState.idle())
+
+                verify(searchView).hideProgress()
+
+            }
+
+            "FloatingSearchView should not have interaction on null state" {
+                val searchView = mock<FloatingSearchView>()
+
+                searchView.bindSuggestions(null)
+
+                verifyZeroInteractions(searchView)
+
+            }
+
+            "FloatingSearchView should show human description on error state" {
+                assertAll(Gen.suggestionsErrorViewState()) { state ->
+                    val captor = argumentCaptor<List<SearchSuggestion>>()
+                    val searchView = mock<FloatingSearchView> {
+                        doNothing().whenever(it).swapSuggestions(captor.capture())
+                    }
+
+                    searchView.bindSuggestions(state)
+
+                    verify(searchView).swapSuggestions(any())
+
+                    with(captor.firstValue) {
+                        assertEquals(1, size)
+                        assertEquals(state._error.toHumanResponse(), get(0).body)
+                    }
+                }
+            }
+
+            "FloatingSearchView should show results on result state" {
+                assertAll(Gen.suggestionsResultViewState()) { state ->
+                    val captor = argumentCaptor<List<SearchSuggestion>>()
+                    val searchView = mock<FloatingSearchView> {
+                        doNothing().whenever(it).swapSuggestions(captor.capture())
+                    }
+
+                    searchView.bindSuggestions(state)
+
+                    verify(searchView).swapSuggestions(any())
+
+                    with(captor.firstValue) {
+                        assertEquals(state._results.size, size)
+                        assertEquals(state._results, this.map { it.body })
+                    }
+                }
+            }
+        })
+

--- a/app/src/test/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapterSpec.kt
+++ b/app/src/test/java/es/ffgiraldez/comicsearch/query/sugestion/ui/SuggestionBindingAdapterSpec.kt
@@ -16,72 +16,71 @@ import es.ffgiraldez.comicsearch.query.base.ui.toHumanResponse
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.assertAll
 import io.kotlintest.specs.StringSpec
-import junit.framework.Assert.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 
-class SuggestionBindingAdapterSpec :
-        StringSpec({
-            "FloatingSearchView should show progress on loading state" {
-                val searchView = mock<FloatingSearchView>()
+class SuggestionBindingAdapterSpec : StringSpec({
+    "FloatingSearchView should show progress on loading state" {
+        val searchView = mock<FloatingSearchView>()
 
-                searchView.bindSuggestions(QueryViewState.loading())
+        searchView.bindSuggestions(QueryViewState.loading())
 
-                verify(searchView).showProgress()
+        verify(searchView).showProgress()
 
+    }
+
+    "FloatingSearchView should hide progress on non loading state" {
+        val searchView = mock<FloatingSearchView>()
+
+        searchView.bindSuggestions(QueryViewState.idle())
+
+        verify(searchView).hideProgress()
+
+    }
+
+    "FloatingSearchView should not have interaction on null state" {
+        val searchView = mock<FloatingSearchView>()
+
+        searchView.bindSuggestions(null)
+
+        verifyZeroInteractions(searchView)
+
+    }
+
+    "FloatingSearchView should show human description on error state" {
+        assertAll(Gen.suggestionsErrorViewState()) { state ->
+            val captor = argumentCaptor<List<SearchSuggestion>>()
+            val searchView = mock<FloatingSearchView> {
+                doNothing().whenever(it).swapSuggestions(captor.capture())
             }
 
-            "FloatingSearchView should hide progress on non loading state" {
-                val searchView = mock<FloatingSearchView>()
+            searchView.bindSuggestions(state)
 
-                searchView.bindSuggestions(QueryViewState.idle())
+            verify(searchView).swapSuggestions(any())
 
-                verify(searchView).hideProgress()
+            with(captor.firstValue) {
+                assertEquals(1, size)
+                assertEquals(state._error.toHumanResponse(), get(0).body)
+            }
+        }
+    }
 
+    "FloatingSearchView should show results on result state" {
+        assertAll(Gen.suggestionsResultViewState()) { state ->
+            val captor = argumentCaptor<List<SearchSuggestion>>()
+            val searchView = mock<FloatingSearchView> {
+                doNothing().whenever(it).swapSuggestions(captor.capture())
             }
 
-            "FloatingSearchView should not have interaction on null state" {
-                val searchView = mock<FloatingSearchView>()
+            searchView.bindSuggestions(state)
 
-                searchView.bindSuggestions(null)
+            verify(searchView).swapSuggestions(any())
 
-                verifyZeroInteractions(searchView)
-
+            with(captor.firstValue) {
+                assertEquals(state._results.size, size)
+                assertEquals(state._results, this.map { it.body })
             }
-
-            "FloatingSearchView should show human description on error state" {
-                assertAll(Gen.suggestionsErrorViewState()) { state ->
-                    val captor = argumentCaptor<List<SearchSuggestion>>()
-                    val searchView = mock<FloatingSearchView> {
-                        doNothing().whenever(it).swapSuggestions(captor.capture())
-                    }
-
-                    searchView.bindSuggestions(state)
-
-                    verify(searchView).swapSuggestions(any())
-
-                    with(captor.firstValue) {
-                        assertEquals(1, size)
-                        assertEquals(state._error.toHumanResponse(), get(0).body)
-                    }
-                }
-            }
-
-            "FloatingSearchView should show results on result state" {
-                assertAll(Gen.suggestionsResultViewState()) { state ->
-                    val captor = argumentCaptor<List<SearchSuggestion>>()
-                    val searchView = mock<FloatingSearchView> {
-                        doNothing().whenever(it).swapSuggestions(captor.capture())
-                    }
-
-                    searchView.bindSuggestions(state)
-
-                    verify(searchView).swapSuggestions(any())
-
-                    with(captor.firstValue) {
-                        assertEquals(state._results.size, size)
-                        assertEquals(state._results, this.map { it.body })
-                    }
-                }
-            }
-        })
+        }
+    }
+})
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  #12 
### :tophat: What is the goal?

Cover UI Binding with unit tests, as `@BindingAdapter` use [pure functions](https://en.wikipedia.org/wiki/Pure_function) and are static methods, we could cover with it with unit test.

### :memo: How is it being implemented?
`@BindingAdapter` needs the view that receives the binding  logic as the first argument, this behaviour has a specific encoding in Kotlin, aka  [extension function](https://kotlinlang.org/docs/reference/extensions.html#extension-functions), so here adapt all binding previously in a java style into a kotlin one

### :boom: How can it be tested?

🤖 just run all the tests 😃 